### PR TITLE
Add mitake notification driver in MitakeServiceProvider

### DIFF
--- a/src/MitakeServiceProvider.php
+++ b/src/MitakeServiceProvider.php
@@ -3,6 +3,8 @@
 namespace NotificationChannels\Mitake;
 
 use GuzzleHttp\Client;
+use Illuminate\Notifications\ChannelManager;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\ServiceProvider;
 
 class MitakeServiceProvider extends ServiceProvider
@@ -29,5 +31,11 @@ class MitakeServiceProvider extends ServiceProvider
                     config('services.mitake.url')
                 );
             });
+
+        Notification::resolved(function (ChannelManager $service) {
+            $service->extend('mitake', function ($app) {
+                return $app->make(MitakeChannel::class);
+            });
+        });
     }
 }


### PR DESCRIPTION
Hi @natsumework ,
Thanks for your notification channel implementation. I found if there is no mitake notification driver in `MitakeServiceProvider`, it appears _Driver [mitake] not supported_ execption. Therefore, I wrote a code snippet to add mitake driver in `MitakeServiceProvider`. Please take a look.